### PR TITLE
Add FastAPI API for boat filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This will open a beautiful web interface at `http://localhost:8501`
 ```bash
 python filters3.py
 ```
+#### Option 3: FastAPI Service
+```bash
+uvicorn api:app --reload
+```
+Use `/boats?query=<your query>` to retrieve matching boat IDs.
+
 
 ## 📊 Dataset Format
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel
+import polars as pl
+
+from app import load_dataset, query_boats
+
+app = FastAPI(title="Boat Filter API")
+
+df = load_dataset()
+
+class QueryPayload(BaseModel):
+    query: str
+
+@app.get("/boats")
+@app.post("/boats")
+async def boats(q: str = Query(None, alias="query"), payload: QueryPayload | None = None):
+    query = q or (payload.query if payload else "")
+    if not query:
+        raise HTTPException(status_code=400, detail="Query is required")
+
+    _, results, _ = query_boats(df, query)
+    if results.is_empty():
+        return {"ids": []}
+
+    if "id" not in results.columns:
+        results = results.with_row_count("id")
+
+    return {"ids": results["id"].to_list()}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ polars>=0.20.0
 google-generativeai>=0.3.0
 python-dotenv>=1.0.0
 pandas>=2.0.0 
+fastapi>=0.110.0
+uvicorn>=0.25.0


### PR DESCRIPTION
## Summary
- add FastAPI and uvicorn requirements
- implement a simple `api.py` exposing a `/boats` endpoint
- document FastAPI usage in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6866945de9508325b007690b1eaf05f9