### PR TITLE
Fix README ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,4 +196,4 @@ If you encounter issues:
 
 ---
 
-**Made with ❤️ using Streamlit, Polars, and Google Gemini AI** 
+**Made with ❤️ using Streamlit, Polars, and Google Gemini AI**


### PR DESCRIPTION
## Summary
- clean up trailing space after the final line
- ensure README ends with a newline

## Testing
- `python -m py_compile app.py api.py deploy.py filters3.py`


------
https://chatgpt.com/codex/tasks/task_e_686696041af08325922bdb3b26469734