### PR TITLE
Fix numeric query edit rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -453,7 +453,7 @@ def main():
 
         if updated_query != st.session_state["query_input"]:
             st.session_state["updated_query"] = updated_query
-            st.experimental_rerun()
+            st.rerun()
 
         st.markdown(highlight_numbers_html(st.session_state.get("query_input", "")), unsafe_allow_html=True)
     


### PR DESCRIPTION
## Summary
- call `st.rerun()` instead of deprecated `st.experimental_rerun`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866aacb4bcc8325be8e88ecbb78f8b9